### PR TITLE
EL-3937 - Update Chrome to 83

### DIFF
--- a/release-notes-1.4.0.md
+++ b/release-notes-1.4.0.md
@@ -1,6 +1,7 @@
 #### Version Number
-* Update `google-chrome`.
+${version-number}
 
 #### New Features
+* Update `google-chrome` to version 83.
 
 #### Known Issues

--- a/release-notes-1.4.0.md
+++ b/release-notes-1.4.0.md
@@ -1,7 +1,5 @@
-!not-ready-for-release!
-
 #### Version Number
-${version-number}
+* Update `google-chrome`.
 
 #### New Features
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN dpkg -i google-chrome-stable_83.0.4103.97-1_amd64.deb; apt-get -fy install
 #
 # Fetch chromedriver to save a download on every build
 #
-RUN curl https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip --create-dirs -o /tmp
+RUN curl https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip --create-dirs -o /tmp/chromedriver_linux64.zip
 
 #
 # Tag the image

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,6 +35,11 @@ RUN wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/
 RUN dpkg -i google-chrome-stable_83.0.4103.97-1_amd64.deb; apt-get -fy install
 
 #
+# Fetch chromedriver to save a download on every build
+#
+RUN curl https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip --create-dirs -o /tmp
+
+#
 # Tag the image
 #
 ARG BUILD_NUMBER

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -31,8 +31,8 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 #
 # Install Chrome (Required for automated tests)
 #
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
+RUN wget http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_83.0.4103.97-1_amd64.deb
+RUN dpkg -i google-chrome-stable_83.0.4103.97-1_amd64.deb; apt-get -fy install
 
 #
 # Tag the image


### PR DESCRIPTION
* Update to Chrome 83.
* Include chromedriver in the image, this saves a download during the install phase.

CI image: cafinternal/prereleases:buildenv-1.4.0-EL-3937-update-chrome-SNAPSHOT