### PR TITLE
Cypress dependencies

### DIFF
--- a/release-notes-2.1.0.md
+++ b/release-notes-2.1.0.md
@@ -1,8 +1,7 @@
-!not-ready-for-release!
-
 #### Version Number
 ${version-number}
 
 #### New Features
+- Add Cypress dependencies.
 
 #### Known Issues

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -38,3 +38,8 @@ RUN dpkg -i google-chrome-stable_83.0.4103.97-1_amd64.deb; apt-get -fy install
 # Fetch chromedriver to save a download on every build
 #
 RUN curl https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip --create-dirs -o /tmp/chromedriver_linux64.zip
+
+#
+# Install Cypress Dependencies
+#
+RUN apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb


### PR DESCRIPTION
I decided to use Cypress in the deploy test project since Protractor is more or less deprecated. I did not use the build image that Universal uses because it packages NPM 7, which still emits some peer conflict errors in the UX Aspects projects.