### PR TITLE
update image to Node 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2021 Micro Focus or one of its affiliates.
+    Copyright 2022 Micro Focus or one of its affiliates.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@
     </developers>
 
     <properties>
-        <copyrightYear>2021</copyrightYear>
+        <copyrightYear>2022</copyrightYear>
         <copyrightNotice>Copyright ${copyrightYear} Micro Focus or one of its affiliates.</copyrightNotice>
         <dockerHubOrganization>uxaspects</dockerHubOrganization>
         <dockerUXAspectsOrg>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerUXAspectsOrg>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -44,4 +44,4 @@ RUN curl https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_l
 #
 # Install Cypress Dependencies
 #
-RUN apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+RUN apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb build-essential

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,9 +15,9 @@
 #
 
 #
-# Base on the JDK 11 image
+# Base on the standard Maven 3.5.3 image
 #
-FROM cafapi/buildenv-jdk11:1.0.0
+FROM maven:3.8.4-jdk-11
 
 #
 # Install Node.js (which includes npm)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,9 +15,9 @@
 #
 
 #
-# Base on the standard Maven 3.5.3 image
+# Base on the JDK 11 image
 #
-FROM maven:3.5.3-jdk-8
+FROM cafapi/buildenv-jdk11:1.0.0
 
 #
 # Install Node.js (which includes npm)

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 # Note: Google has phased out fetching a specific version of Chrome, which is why we're fetching from a mirror:
 # https://stackoverflow.com/questions/70752674/404-on-dl-google-com-for-stable-chrome
 RUN wget http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_99.0.4844.51-1_amd64.deb
-RUN apt install ./google-chrome-stable_99.0.4844.51-1_amd64.deb
+RUN apt install -y ./google-chrome-stable_99.0.4844.51-1_amd64.deb
 
 #
 # Fetch chromedriver to save a download on every build

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Micro Focus or one of its affiliates.
+# Copyright 2022 Micro Focus or one of its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ FROM maven:3.5.3-jdk-8
 #
 # Install Node.js (which includes npm)
 #
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs && \
     echo "Node.js version: $(node -v)" && \
-    npm install npm@6 -g && \
+    npm install npm -g && \
     echo "NPM version: $(npm -v)"
 
 #

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -33,14 +33,13 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 #
 # Note: Google has phased out fetching a specific version of Chrome, which is why we're fetching from a mirror:
 # https://stackoverflow.com/questions/70752674/404-on-dl-google-com-for-stable-chrome
-RUN wget http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_83.0.4103.97-1_amd64.deb
-RUN dpkg -i google-chrome-stable_83.0.4103.97-1_amd64.deb; apt-get -fy install
-ENV CHROME_BIN='/usr/bin/google-chrome'
+RUN wget http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_99.0.4844.51-1_amd64.deb
+RUN apt install ./google-chrome-stable_99.0.4844.51-1_amd64.deb
 
 #
 # Fetch chromedriver to save a download on every build
 #
-RUN curl https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip --create-dirs -o /tmp/chromedriver_linux64.zip
+RUN curl https://chromedriver.storage.googleapis.com/99.0.4844.35/chromedriver_linux64.zip --create-dirs -o /tmp/chromedriver_linux64.zip
 
 #
 # Install Cypress Dependencies

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -33,13 +33,13 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 #
 # Note: Google has phased out fetching a specific version of Chrome, which is why we're fetching from a mirror:
 # https://stackoverflow.com/questions/70752674/404-on-dl-google-com-for-stable-chrome
-RUN wget http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_99.0.4844.51-1_amd64.deb
-RUN apt install -y ./google-chrome-stable_99.0.4844.51-1_amd64.deb
+RUN wget http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_98.0.4758.102-1_amd64.deb
+RUN apt install -y ./google-chrome-stable_98.0.4758.102-1_amd64.deb
 
 #
 # Fetch chromedriver to save a download on every build
 #
-RUN curl https://chromedriver.storage.googleapis.com/99.0.4844.35/chromedriver_linux64.zip --create-dirs -o /tmp/chromedriver_linux64.zip
+RUN curl https://chromedriver.storage.googleapis.com/98.0.4758.102/chromedriver_linux64.zip --create-dirs -o /tmp/chromedriver_linux64.zip
 
 #
 # Install Cypress Dependencies

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
 # https://stackoverflow.com/questions/70752674/404-on-dl-google-com-for-stable-chrome
 RUN wget http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_83.0.4103.97-1_amd64.deb
 RUN dpkg -i google-chrome-stable_83.0.4103.97-1_amd64.deb; apt-get -fy install
+ENV CHROME_BIN='/usr/bin/google-chrome'
 
 #
 # Fetch chromedriver to save a download on every build


### PR DESCRIPTION
Node 12 exits LTS in April 2022, so we are moving to Node 16 (the current LTS version).
- update Node and NPM
- update the base image
- update Chrome
- added `build-essential` for `make` which is needed for a postinstall step of one of the quantum dependencies

Downstream branches to test:
- https://github.com/UXAspects/UXAspects/pull/1635
- https://github.houston.softwaregrp.net/caf/quantum-ux-aspects/pull/242
- https://github.houston.softwaregrp.net/caf/ux-aspects-micro-focus/pull/854

Note: I didn't update the quantum build image because the quantum bootstrap documentation site uses a very old dependency which doesn't deploy with Node 16, and I don't want to mess with it because it doesn't have any regression tests. The quantum variables don't have any build steps so a developer for UX Aspects should be able to use Node 16 with no problem.